### PR TITLE
Fixing the injected style to work with slack v3.1.0

### DIFF
--- a/old-slack-emojis.bat
+++ b/old-slack-emojis.bat
@@ -71,7 +71,7 @@ IF "%UNINSTALL%" == "-u" (
 
 >"%SLACK_DIR%\old-slack-emojis.js" (
     ECHO.var emojiStyle = document.createElement('style'^);
-    ECHO.emojiStyle.innerText = ".emoji-sizer[style*='sheet_google_64_indexed_256.png'], .emoji[style*='sheet_google_64_indexed_256.png'] { background-image: url('https://old-slack-emojis.cf/cdn/slack_2016_apple_sprite_64.png') !important; }";
+    ECHO.emojiStyle.innerText = ".emoji-outer { background-image: url('https://old-slack-emojis.cf/cdn/slack_2016_apple_sprite_64.png') !important; }";
     ECHO.document.head.appendChild(emojiStyle^);
 )
 

--- a/old-slack-emojis.sh
+++ b/old-slack-emojis.sh
@@ -100,7 +100,7 @@ fi
 
 cat <<EOF > $SLACK_DIR/old-slack-emojis.js
 var emojiStyle = document.createElement('style');
-emojiStyle.innerText = ".emoji-sizer[style*='sheet_google_64_indexed_256.png'], .emoji[style*='sheet_google_64_indexed_256.png'] { background-image: url('https://old-slack-emojis.cf/cdn/slack_2016_apple_sprite_64.png') !important; }";
+emojiStyle.innerText = ".emoji-outer { background-image: url('https://old-slack-emojis.cf/cdn/slack_2016_apple_sprite_64.png') !important; }";
 document.head.appendChild(emojiStyle);
 EOF
 


### PR DESCRIPTION
The way Slack styles their emojis has changed slightly. They now use the `emoji-outer` class for built-in emojis.

Addresses #3 